### PR TITLE
Fixed issue with default value for Dict key

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ def read(fname):
 
 
 setupconf = dict(
-<<<<<<< HEAD
     name='trafaret',
     version='0.5.0',
     license='BSD',
@@ -32,21 +31,6 @@ setupconf = dict(
         ]
     ),
     classifiers=[
-=======
-    name = 'trafaret',
-    version = '0.4.1',
-    license = 'BSD',
-    url = 'https://github.com/Deepwalker/trafaret/',
-    author = 'Barbuza, Deepwalker',
-    author_email = 'krivushinme@gmail.com',
-    description = ('Validation and parsing library'),
-    long_description = read('README.rst'),
-    keywords = 'validatation form forms data schema',
-
-    packages = ['trafaret'],
-
-    classifiers = [
->>>>>>> bcd86e61d84d38ee1b5ebd3f18cc408604256d61
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/trafaret/__init__.py
+++ b/trafaret/__init__.py
@@ -838,7 +838,7 @@ class Key(object):
 
     """
     Helper class for Dict.
-    
+
     >>> default = lambda: 1
     >>> Key(name='test', default=default)
     <Key "test">
@@ -874,7 +874,8 @@ class Key(object):
             yield self.get_name(), catch_error(self.trafaret,
                     data.pop(self.name, default))
             raise StopIteration
-        if not self.optional:
+
+        if not self.optional and self.name not in data:
             yield self.name, DataError(error='is required')
 
     def keys_names(self):
@@ -892,7 +893,6 @@ class Key(object):
 
     def make_optional(self):
         self.optional = True
-        self.default = None
 
     def __repr__(self):
         return '<%s "%s"%s>' % (self.__class__.__name__, self.name,

--- a/trafaret/__init__.py
+++ b/trafaret/__init__.py
@@ -875,7 +875,7 @@ class Key(object):
                     data.pop(self.name, default))
             raise StopIteration
 
-        if not self.optional and self.name not in data:
+        if not self.optional:
             yield self.name, DataError(error='is required')
 
     def keys_names(self):


### PR DESCRIPTION
This fix for situations:

```
t.Dict({t.Key("field", optional=True): t.String}).check({}) != \
    t.Dict(field=t.String).make_optional("field").check({})
```
