### PR TITLE
Update __init__.py

### DIFF
--- a/trafaret/__init__.py
+++ b/trafaret/__init__.py
@@ -588,7 +588,7 @@ class String(Trafaret):
             match = self.regex.match(value)
             if not match:
                 self._failure("value '%s' does not match pattern: %s" % (
-                    value, self._raw_regex)
+                    value, repr(self._raw_regex))
                 )
             return match
         return value


### PR DESCRIPTION
I use next regex:
regex = re.compile(
        r'(?=^.{1,254}$)(^(((?!-)[a-zA-Z0-9-]{1,63}(?<!-))|((?!-)[a-zA-Z0-9-]{1,63}(?<!-)‌​.)+[a-zA-Z]{2,63})$)', re.IGNORECASE)

In case of re.match failure I get:
File "venv/lib/python2.7/site-packages/trafaret/**init**.py", line 591, in check_and_return
    value, self._raw_regex)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 79: ordinal not in range(128)

My fix excludes this situation.
