### PR TITLE
Add max_length to Email (254) & update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 \.settings
 \.project
 \.pydevproject
+*.egg-info

--- a/trafaret/__init__.py
+++ b/trafaret/__init__.py
@@ -46,6 +46,8 @@ __all__ = ("DataError", "Trafaret", "Any", "Int", "String",
 
 ENTRY_POINT = 'trafaret'
 _empty = object()
+MAX_EMAIL_LEN = 254
+
 
 def py3metafix(cls):
     if not py3:
@@ -627,10 +629,12 @@ class Email(String):
         r')@(?P<domain>(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)$)'  # domain
         r'|\[(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}\]$', re.IGNORECASE)  # literal form, ipv4 address (SMTP 4.1.3)
     min_length = None
-    max_length = None
+    max_length = MAX_EMAIL_LEN
 
     def __init__(self, allow_blank=False):
-        super(Email, self).__init__(allow_blank=allow_blank, regex=self.regex)
+        super(Email, self).__init__(allow_blank=allow_blank,
+                                    regex=self.regex,
+                                    max_length=self.max_length)
 
     def check_and_return(self, value):
         try:


### PR DESCRIPTION
According to links
http://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address
http://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690
limit is 254.
In current version I can do:

```
t.Email().check('x' * 100000 + '@ukr.net')
```

and it's valid.
