### PR TITLE
allow_blank for MongoId, unitttest MongoId.

### DIFF
--- a/trafaret/contrib/object_id.py
+++ b/trafaret/contrib/object_id.py
@@ -6,10 +6,26 @@ from .. import Trafaret, str_types
 
 class MongoId(Trafaret):
     """ Trafaret type check & convert bson.ObjectId values
+    allow_blank: if False it won't generate new ObjectId from None value.
+
+    >>> MongoId()
+    <MongoId>
+    >>> MongoId(allow_blank=True)
+    <MongoId(blank)>
+    >>> MongoId().check("5583f69d690b2d70a4afdfae")
+    ObjectId('5583f69d690b2d70a4afdfae')
+    >>> MongoId(allow_blank=True).check(None)
+    ObjectId('5583f6e9690b2d70a4afdfaf')
+    >>>extract_error(MongoId(), "just_id")
+    "'just_id' is not a valid ObjectId, it must be a 12-byte input or a 24-character hex string"
     """
 
     convertable = str_types + (ObjectId,)
     value_type = ObjectId
+    allow_blank = False
+
+    def __init__(self, allow_blank=False):
+        self.allow_blank = allow_blank
 
     def __repr__(self):
         return "<MongoId(blank)>" if self.allow_blank else "<MongoId>"
@@ -21,8 +37,9 @@ class MongoId(Trafaret):
             self._failure(e.message)
 
     def check_and_return(self, value):
-
-        if isinstance(value, self.convertable):
+        if not self.allow_blank and value is None:
+            self._failure("blank value is not allowed")
+        if isinstance(value, self.convertable) or value is None:
             return value
 
         self._failure('value is not %s' % self.value_type.__name__)

--- a/utests.py
+++ b/utests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import unittest
 import trafaret as t
 from trafaret import extract_error, ignore
@@ -440,6 +441,31 @@ class TestURLTrafaret(unittest.TestCase):
         self.assertEqual(res, 'http://xn--e1afmkfd.xn--p1ai/resource/?param=value#anchor')
 
 
+class TestMongoIdTrafaret(unittest.TestCase):
+
+    def test_mongo_id(self):
+        from trafaret.contrib.object_id import ObjectId
+        c = t.MongoId()
+        self.assertIsInstance(repr(c), str)
+        self.assertEqual(c.check("5583f69d690b2d70a4afdfae"),
+                         ObjectId('5583f69d690b2d70a4afdfae'))
+        res = extract_error(c, 'just_id')
+        self.assertEqual(res, "'just_id' is not a valid ObjectId, it must be"
+                              " a 12-byte input or a 24-character hex string")
+
+        res = extract_error(c, None)
+        self.assertEqual(res, "blank value is not allowed")
+
+    def test_mongo_id_blank(self):
+        from trafaret.contrib.object_id import ObjectId
+        c = t.MongoId(allow_blank=True)
+        self.assertEqual(c.check("5583f69d690b2d70a4afdfae"),
+                         ObjectId('5583f69d690b2d70a4afdfae'))
+        res = extract_error(c, 'just_id')
+        self.assertEqual(res, "'just_id' is not a valid ObjectId, it must be"
+                              " a 12-byte input or a 24-character hex string")
+
+        self.assertIsInstance(c.check(None), ObjectId)
 
 # res = @guard(a=String, b=Int, c=String)
 #     def fn(a, b, c="default"):


### PR DESCRIPTION
Initially it starts from error when `__repr__` of `MongoId` was failing:

```
AttributeError("'MongoId' object has no attribute 'allow_blank'") raised in repr()
```
