### PR TITLE
fixed packaging errors, made contrib packaging exceptions raise on contrib trafaret access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 \.project
 \.pydevproject
 *.egg-info
+build/
+dist/
+.idea/
+.coverage

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+2016-03-31
+----------
+Fixed loading contrib modules, so now original contrib module loading exception will be raised on contrib Trafaret access.
+
 2016-03-18
 ----------
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 setupconf = dict(
     name='trafaret',
-    version='0.6.3',
+    version='0.6.4',
     license='BSD',
     url='https://github.com/Deepwalker/trafaret/',
     author='Barbuza, Deepwalker, nimnull',


### PR DESCRIPTION
this adds raising original error on contrib module missing, also fixes the case with some versions of `pkgutils` raising `UndefinedEnvironmentName` on `entrypoint.load` with `require` parameter `True`
