### PR TITLE
add subclass trafaret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 dist/
 .idea/
 .coverage
+.tox/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+2016-08-03
+----------
+Added ``Subclass`` trafaret.
+
 2016-03-31
 ----------
 Fixed loading contrib modules, so now original contrib module loading exception will be raised on contrib Trafaret access.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 setupconf = dict(
     name='trafaret',
-    version='0.7.1',
+    version='0.7.2',
     license='BSD',
     url='https://github.com/Deepwalker/trafaret/',
     author='Barbuza, Deepwalker, nimnull',

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -533,6 +533,22 @@ class TestTypeTrafaret(unittest.TestCase):
         self.assertEqual(res, 'value is not int')
 
 
+class TestSubclassTrafaret(unittest.TestCase):
+
+    def test_subclass(self):
+        res = t.Subclass(type)
+        self.assertEqual(repr(res), '<Subclass(type)>')
+        c = t.Subclass[type]
+
+        class Type(type):
+            pass
+
+        res = c.check(Type)
+        self.assertEqual(res, Type)
+        res = extract_error(c, object)
+        self.assertEqual(res, 'value is not subclass of type')
+
+
 class TestURLTrafaret(unittest.TestCase):
 
     def test_url(self):


### PR DESCRIPTION
it is sometimes convenient to combine subclassing checks with `@guard` , especially taking in mind generous trafaret errors output (as compared to usual practice of asserting on `issubclass` in function)
