### PR TITLE
Remove deprecation warning

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,8 +1,21 @@
+import sys
 import doctest
 import trafaret
 from trafaret import utils, extras, visitor
 
-doctest.testmod(m=trafaret)
-doctest.testmod(m=extras)
-doctest.testmod(m=utils)
-doctest.testmod(m=visitor)
+tests = (
+    doctest.testmod(m=trafaret),
+    doctest.testmod(m=extras),
+    doctest.testmod(m=utils),
+    doctest.testmod(m=visitor),
+)
+
+
+def sum_failed(tests_failed, test_results):
+    return tests_failed + test_results.failed
+
+failed = reduce(sum_failed, tests, 0)
+if failed:
+    print('%s tests failed' % failed)
+    sys.exit(1)
+

--- a/trafaret/__init__.py
+++ b/trafaret/__init__.py
@@ -226,7 +226,7 @@ class Subclass(TypingTrafaret):
     <Subclass(type)>
     >>> s = Subclass[type]
     >>> s.check(type)
-    type
+    <type 'type'>
     >>> extract_error(s, object)
     'value is not subclass of type'
     """
@@ -1332,7 +1332,7 @@ def guard(trafaret=None, **kwargs):
     >>> help(fn)
     Help on function fn:
     <BLANKLINE>
-    fn(a, b, c='default')
+    fn(*args, **kwargs)
         guarded with <Dict(a=<String>, b=<Int>, c=<String>)>
     <BLANKLINE>
         docstring
@@ -1449,7 +1449,8 @@ class MissingContribModuleStub(types.ModuleType):
 def load_contrib():
     for entrypoint in pkg_resources.iter_entry_points(ENTRY_POINT):
         try:
-            trafaret_class = entrypoint.load(require=False)
+            trafaret_class = entrypoint.resolve()
+
         except (pkg_resources.DistributionNotFound, ImportError) as err:
             trafaret_class = MissingContribModuleStub(entrypoint, err)
 


### PR DESCRIPTION
## Rationale

When importing trafaret deprecation warning was very annoying

```
trafaret/__init__.py:1452: DeprecationWarning: Parameters to load are deprecated.  Call .resolve and .require separately.
  trafaret_class = entrypoint.load(require=False)
```

This PR aimed to remove warning
## Changes
- Remove warning by proper invocation of `entrypoint.resolve()`
- Fix docstring tests to pass
- Add check for any failed test, so now in case of error exit code of `test.py` will be non-zero as it should be, instead of `python test.py -v` that passed silently
## Testing

Tested only locally with `tox`
## Questions
- Is there Travis integration that will launch tests on PR? I saw `.travis.yml`?
- If there is `tox.ini` config should I also add tox to the dependencies and also provide correct entrypoint to `setup.py` file to be able launch `python setup.py test`?
