### PR TITLE
Adds `trafaret` parameter to DataError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+
+2016-09-25
+----------
+
+Added ``trafaret`` argument to ``DataError`` constructor and made ``_failure``
+a method (rather than static method)
+
+
 2016-08-03
 ----------
 Added ``Subclass`` trafaret.

--- a/trafaret/__init__.py
+++ b/trafaret/__init__.py
@@ -63,12 +63,13 @@ class DataError(ValueError):
     error can be a message or None if error raised in childs
     data can be anything
     """
-    __slots__ = ['error', 'name', 'value']
+    __slots__ = ['error', 'name', 'value', 'trafaret']
 
-    def __init__(self, error=None, name=None, value=_empty):
+    def __init__(self, error=None, name=None, value=_empty, trafaret=None):
         self.error = error
         self.name = name
         self.value = value
+        self.trafaret = trafaret
 
     def __str__(self):
         return str(self.error)
@@ -151,12 +152,11 @@ class Trafaret(object):
             val = converter(val)
         return val
 
-    @staticmethod
-    def _failure(error=None, value=_empty):
+    def _failure(self, error=None, value=_empty):
         """
         Shortcut method for raising validation error
         """
-        raise DataError(error=error, value=value)
+        raise DataError(error=error, value=value, trafaret=self)
 
     @staticmethod
     def _trafaret(trafaret):
@@ -304,7 +304,7 @@ class Or(Trafaret):
                 return trafaret.check(value)
             except DataError as e:
                 errors.append(e)
-        raise DataError(dict(enumerate(errors)))
+        raise DataError(dict(enumerate(errors)), trafaret=self)
 
     def __lshift__(self, trafaret):
         self.trafarets.append(self._trafaret(trafaret))
@@ -819,7 +819,7 @@ class List(Trafaret):
             except DataError as err:
                 errors[index] = err
         if errors:
-            raise DataError(error=errors)
+            raise DataError(error=errors, trafaret=self)
         return lst
 
     def __repr__(self):
@@ -1065,7 +1065,7 @@ class Dict(Trafaret):
                 elif key not in collect:
                     collect[key] = value[key]
         if errors:
-            raise DataError(error=errors)
+            raise DataError(error=errors, trafaret=self)
         return collect
 
     def keys_names(self):
@@ -1180,7 +1180,7 @@ class Mapping(Trafaret):
             else:
                 checked_mapping[checked_key] = checked_value
         if errors:
-            raise DataError(error=errors)
+            raise DataError(error=errors, trafaret=self)
         return checked_mapping
 
     def __repr__(self):


### PR DESCRIPTION
This also sets the parameter where possible (and unambiguous). I'm not adding trafaret in keys of the dictionary and some similar places, because I'm not sure they are useful. They might be added in additional commits.

The parameter might be used for better error display by accessing original parameters of a trafaret.

Original intention was to implement nicer display for `Or` alternatives in `trafaret_config` package. There is an [example test](https://github.com/tailhook/trafaret_config/blob/38255eb8f345acdc5cdef14c8e432e5716251e77/tests/test_alternatives.py) that shows the difference (note `if BEAUTY_ERROR:` in two test suites), note that we not only can't make shorter errors we also don't have a good heuristic to guess line numbers inside any of the alternative branches
