### PR TITLE
Check that underlying object of `partial` is subclass of Trafaret

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -40,7 +40,7 @@ Some way you can use all re.Match power to extract from strings dicts and so on.
 functools.partial
 .................
 
-You can use ``functools.partial`` with Trafaret subclasses::
+You can use ``functools.partial`` with trafaret::
 
     >>> Word = functools.partial(t.String, regex=r'^[a-zA-Z]+$')
     >>> ShortWord = functools.partial(Word, min_length=3, max_length=5)

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -37,6 +37,16 @@ Regex String
 
 Some way you can use all re.Match power to extract from strings dicts and so on.
 
+functools.partial
+.................
+
+You can use ``functools.partial`` with Trafaret subclasses::
+
+    >>> Word = functools.partial(t.String, regex=r'^[a-zA-Z]+$')
+    >>> ShortWord = functools.partial(Word, min_length=3, max_length=5)
+    >>> d = t.Dict({'short_word': ShortWord})
+    >>> d.check({'short_word': 'foo'})
+    {'short_word': 'foo'}
 
 Dict and Key
 ............

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -710,7 +710,8 @@ class TestPartialTrafaret(unittest.TestCase):
 
     def test_wrong_partial(self):
         trafaret = partial(
-            lambda min_length: t.String(min_length=min_length),
+            lambda min_length: min_length,
+            min_length=2,
         )
         with self.assertRaises(TypeError):
             trafaret = t.Dict({

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,6 +2,7 @@
 import unittest
 import trafaret as t
 from collections import Mapping as AbcMapping
+from functools import partial
 from trafaret import extract_error, ignore, DataError
 from trafaret.extras import KeysSubset
 
@@ -636,6 +637,85 @@ class TestDataError(unittest.TestCase):
         trafaret = t.Int()
         val = t.catch(trafaret, 'a') or 100
         self.assertEqual(val, 100)
+
+
+class TestPartialTrafaret(unittest.TestCase):
+    def test_partial_trafaret(self):
+        trafaret = partial(
+            t.String,
+            min_length=2,
+        )
+        res = trafaret()('ua')
+        self.assertEqual(res, 'ua')
+        with self.assertRaises(t.DataError):
+            trafaret()('u')
+
+        trafaret = partial(
+            trafaret,
+            max_length=3,
+        )
+        res = trafaret()('ukr')
+        self.assertEqual(res, 'ukr')
+        with self.assertRaises(t.DataError):
+            trafaret()('ukra')
+
+    def test_partial_in_dict(self):
+        child_trafaret = partial(
+            t.String,
+            min_length=2,
+        )
+        child_trafaret = partial(
+            child_trafaret,
+            max_length=3,
+        )
+        trafaret = t.Dict({
+            t.Key('country_code'): child_trafaret,
+        })
+        res = trafaret({'country_code': 'ua'})
+        self.assertEqual(res, {'country_code': 'ua'})
+
+        trafaret = t.Dict({
+            t.Key('country_code'): child_trafaret(),
+        })
+        res = trafaret({'country_code': 'ua'})
+        self.assertEqual(res, {'country_code': 'ua'})
+
+    def test_partial_in_list(self):
+        child_trafaret = partial(
+            t.String,
+            min_length=2,
+        )
+        child_trafaret = partial(
+            child_trafaret,
+            max_length=3,
+        )
+        trafaret = t.List(child_trafaret, min_length=1)
+        res = trafaret(['foo', 'bar'])
+        self.assertEqual(res, ['foo', 'bar'])
+
+    def test_partial_Or(self):
+        child_trafaret = partial(
+            t.String,
+            min_length=2,
+        )
+        child_trafaret = partial(
+            child_trafaret,
+            max_length=3,
+        )
+        trafaret = t.Or(child_trafaret, t.Null)
+        res = trafaret('foo')
+        self.assertEqual(res, 'foo')
+        res = trafaret(None)
+        self.assertEqual(res, None)
+
+    def test_wrong_partial(self):
+        trafaret = partial(
+            lambda min_length: t.String(min_length=min_length),
+        )
+        with self.assertRaises(TypeError):
+            trafaret = t.Dict({
+                t.Key('country_code'): trafaret,
+            })
 
 
 # res = @guard(a=String, b=Int, c=String)

--- a/trafaret/__init__.py
+++ b/trafaret/__init__.py
@@ -32,16 +32,6 @@ def _dd(value):
         return repr(value)
     return r"{%s}" % ', '.join("%r: %s" % (x[0], _dd(x[1])) for x in sorted(value.items(), key=lambda x: x[0]))
 
-def _issubclasspartial(fn, cls):
-    while True:
-        parent = fn
-        fn = getattr(parent, 'func', None)
-
-        if fn is None:
-            break
-
-    return issubclass(parent, cls)
-
 """
 Trafaret is tiny library for data validation
 It provides several primitives to validate complex data structures
@@ -179,7 +169,7 @@ class Trafaret(object):
         """
         if isinstance(trafaret, Trafaret) or inspect.isroutine(trafaret):
             return trafaret
-        elif _issubclasspartial(trafaret, Trafaret):
+        elif isinstance(trafaret, functools.partial) or issubclass(trafaret, Trafaret):
             return trafaret()
         elif isinstance(trafaret, type):
             return Type(trafaret)

--- a/trafaret/__init__.py
+++ b/trafaret/__init__.py
@@ -1270,7 +1270,10 @@ class Call(Trafaret):
     def __init__(self, fn):
         if not callable(fn):
             raise RuntimeError("Call argument should be callable")
-        argspec = inspect.getargspec(fn)
+        if py3:
+            argspec = inspect.getfullargspec(fn)
+        else:
+            argspec = inspect.getargspec(fn)
         if len(argspec.args) - len(argspec.defaults or []) > 1:
             raise RuntimeError("Call argument should be"
                                " one argument function")
@@ -1387,7 +1390,10 @@ def guard(trafaret=None, **kwargs):
         trafaret = Dict(**kwargs)
 
     def wrapper(fn):
-        argspec = inspect.getargspec(fn)
+        if py3:
+            argspec = inspect.getfullargspec(fn)
+        else:
+            argspec = inspect.getargspec(fn)
 
         @functools.wraps(fn)
         def decor(*args, **kwargs):

--- a/trafaret/__init__.py
+++ b/trafaret/__init__.py
@@ -32,6 +32,16 @@ def _dd(value):
         return repr(value)
     return r"{%s}" % ', '.join("%r: %s" % (x[0], _dd(x[1])) for x in sorted(value.items(), key=lambda x: x[0]))
 
+def _issubclasspartial(fn, cls):
+    while True:
+        parent = fn
+        fn = getattr(parent, 'func', None)
+
+        if fn is None:
+            break
+
+    return issubclass(parent, cls)
+
 """
 Trafaret is tiny library for data validation
 It provides several primitives to validate complex data structures
@@ -169,7 +179,7 @@ class Trafaret(object):
         """
         if isinstance(trafaret, Trafaret) or inspect.isroutine(trafaret):
             return trafaret
-        elif issubclass(trafaret, Trafaret):
+        elif _issubclasspartial(trafaret, Trafaret):
             return trafaret()
         elif isinstance(trafaret, type):
             return Type(trafaret)


### PR DESCRIPTION
When you have your custom trafarets and some of them differs only with value of arguments,
it is useful to use partial in this case.
Primitive and simple example:
```python
import trafaret as t
import functools

Word = functools.partial(t.String, regex=r'^[a-zA-Z]+$')
ShortWord = functools.partial(Word, min_length=3, max_length=5)
d = t.Dict({'short_word': ShortWord})
d.check({'short_word': 'foo'})
```