### PR TITLE
fix for converters in Regexp and RegexpRaw classes

### DIFF
--- a/trafaret/__init__.py
+++ b/trafaret/__init__.py
@@ -613,7 +613,7 @@ class RegexpRaw(Trafaret):
         self.regexp = re.compile(regexp) if isinstance(regexp, str_types) else regexp
         self.raw_regexp = self.regexp.pattern if self.regexp else None
 
-    def check(self, value):
+    def check(self, value, convert=False):
         if not isinstance(value, str_types):
             self._failure("value is not a string", value=value)
         match = self.regexp.match(value)
@@ -626,7 +626,7 @@ class RegexpRaw(Trafaret):
 
 
 class Regexp(RegexpRaw):
-    def check(self, value):
+    def check(self, value, convert=False):
         return super(Regexp, self).check(value).group()
 
 


### PR DESCRIPTION
When we tries to execute `trafaret.check()` on `Regexp` or `RegexpRaw` instances with converters it rises an error.
```
>>> (t.Regexp('[A-Z]\w+') >> do_something).check('Foo')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "trafaret/__init__.py", line 140, in check
    res_value = self.check_and_return(value)
  File "trafaret/__init__.py", line 337, in check_and_return
    res = self.trafaret.check(value, convert=False)
TypeError: check() got an unexpected keyword argument 'convert'
```

The reason of this issue is that signatures of `Regexp.check` and `Trafaret.check` are different. As `Regexp` is a subclass of `Trafaret` it will be better if signatures of inherited methods will be the same.