### PR TITLE
guard: support keyword-only and annotated functions (Py3)

### DIFF
--- a/trafaret/__init__.py
+++ b/trafaret/__init__.py
@@ -1516,7 +1516,10 @@ def guard(trafaret=None, **kwargs):
         trafaret = Dict(**kwargs)
 
     def wrapper(fn):
-        argspec = inspect.getargspec(fn)
+        if py3:
+            argspec = inspect.getfullargspec(fn)
+        else:
+            argspec = inspect.getargspec(fn)
 
         @functools.wraps(fn)
         def decor(*args, **kwargs):


### PR DESCRIPTION
Decorate annotated function raise `ValueError: Function has keyword-only arguments or annotations, use getfullargspec() API which can support them`

Example:

```python
import trafaret as t

@t.guard(value=(t.Int() | t.Null())
def func(value: int=None):
     pass
```
Tested on Python 3.5

This PR fix that.