### PR TITLE
trafaret/Enum: support Python >=3.4 `enum` module

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
+import sys
 import unittest
 import trafaret as t
+import trafaret.utils as tu
 from collections import Mapping as AbcMapping
 from trafaret import extract_error, ignore, DataError
 from trafaret.extras import KeysSubset
@@ -264,6 +266,26 @@ class TestEnumTrafaret(unittest.TestCase):
         res = extract_error(trafaret, 2)
         self.assertEqual(res, "value doesn't match any variant")
 
+    @unittest.skipIf(sys.version_info < (3, 4),
+        "not supported in this veresion"
+    )
+    def test_enum_py3(self):
+        import enum
+
+        class Colors(enum.Enum):
+            red = 0
+            green = 1
+            blue = 2
+
+        trafaret = t.Enum.from_enum(Colors)
+        self.assertEqual(repr(trafaret), "<Enum('red', 'green', 'blue')>")
+        res = trafaret.check('red')
+        res = trafaret.check('green')
+        res = extract_error(trafaret, 'unknown')
+        self.assertEqual(res, "value doesn't match any variant")
+
+        with self.assertRaises(TypeError):
+            trafaret = t.Enum.from_enum('not a enum instance')
 
 
 class TestFloat(unittest.TestCase):

--- a/trafaret/__init__.py
+++ b/trafaret/__init__.py
@@ -15,11 +15,14 @@ from .lib import py3, py3metafix
 __VERSION__ = (0, 10, 2)
 
 
+enum = None
+
 # Python3 support
 if py3:
     import urllib.parse as urlparse
     str_types = (str, bytes)
     unicode = str
+
 else:
     try:
         from future_builtins import map
@@ -1353,6 +1356,15 @@ class Enum(Trafaret):
 
     def __repr__(self):
         return "<Enum(%s)>" % (", ".join(map(repr, self.variants)))
+
+    @classmethod
+    def from_enum(cls, variant):
+        import enum
+
+        if not isinstance(variant, enum.EnumMeta):
+            raise TypeError("Expect 'enum.EnumMeta' got %r" % type(variant))
+
+        return cls(*(x.name for x in variant))
 
 
 class Callable(Trafaret):

--- a/trafaret/__init__.py
+++ b/trafaret/__init__.py
@@ -1516,7 +1516,10 @@ def guard(trafaret=None, **kwargs):
         trafaret = Dict(**kwargs)
 
     def wrapper(fn):
-        argspec = inspect.getargspec(fn)
+        if py3:
+            argspec = inspect.getfullargspec(fn)
+        else:
+            argspec = inspect.getargspec(fn)
 
         @functools.wraps(fn)
         def decor(*args, **kwargs):


### PR DESCRIPTION
Fix #60 PR

Except filling rule is different. Fill from enum keys.
Cause by default enum lib support getting by key, not by value.

```python
class MyEnum(enum.Enum):
     me = 'developer'

>>> MyEnum['me']
<MyEnum.me: 'developer'>

```

I think it's more clear and straightforward